### PR TITLE
Add text shadow

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -43,6 +43,10 @@ td.dc-table-column._2
 /* change rowChart label color */
 .dc-chart g.row text {
     fill: black;
+    text-shadow:
+      0px 0px 2px white,
+      0px 0px 2px white,
+      0px 0px 2px white;
 }
 
 .nd {


### PR DESCRIPTION
Not sure if everyone will like this, but wanted to propose the idea for making text more readable (dark text on dark color):

![image](https://user-images.githubusercontent.com/68416/29817635-6ee0d9ee-8cd6-11e7-8d5f-c2b310d89c55.png)

![image](https://user-images.githubusercontent.com/68416/29817647-7c426206-8cd6-11e7-890b-c120186a0963.png)

Alternatively we can change the colors to be more light where readability is an issue (e.g. blue in bars).